### PR TITLE
calcite-webpack-ts: Source map

### DIFF
--- a/calcite-webpack-ts/webpack.config.js
+++ b/calcite-webpack-ts/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = function(_, arg) {
         })
       ]
     },
+    devtool: "source-map",
     module: {
       rules: [
         {


### PR DESCRIPTION
Added `devtool: "source-map"` to webpack.config.js